### PR TITLE
content: gh-cgu のプロダクトエントリを追加

### DIFF
--- a/src/content/product/gh-cgu.md
+++ b/src/content/product/gh-cgu.md
@@ -1,0 +1,17 @@
+---
+title: gh-cgu
+subhead: git ユーザープロファイルを管理・切り替える GitHub CLI 拡張
+images:
+  - gh-cgu_image_1.png
+links:
+  Repository: https://github.com/canoypa/gh-cgu
+tags: [GitHub CLI, Go]
+
+publishedAt: 2022-03-22
+---
+
+コミットする際の名前を匿名と実名で切り替えることがあるので、リポジトリごとにパッと `git config user.name` と `git config user.email` を実行するために作成したツール。
+
+`gh cgu add` でプロファイルを登録しておけば、`gh cgu use <key>` で一発切り替えができます。
+
+プロファイルは Gist に同期されるようになっているので、複数マシン間でも共有可能になってます。


### PR DESCRIPTION
gh-cgu (GitHub CLI 拡張) のプロダクトエントリとスクリーンショットを追加。