### PR TITLE
fix: vercel-action を v42.2.0 に更新しデプロイ失敗を修正

### DIFF
--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -2,17 +2,17 @@ name: Production Deploy
 
 on:
   push:
-    branches: [main]
+    branches: [ main ]
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
     environment: Production
     steps:
-      - uses: actions/checkout@v2
-      - uses: amondnet/vercel-action@v25
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: amondnet/vercel-action@4b810e26f7bb2a331c698af186f890cbf20d5f72 # v42.2.0
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
-          vercel-org-id: ${{ secrets.VERCEL_ORG_ID}}
-          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID}}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
           vercel-args: --prod


### PR DESCRIPTION
## 問題

`amondnet/vercel-action@v25` が Vercel CLI 25.1.0 を使用していたが、Vercel のエンドポイントが v47.2.2 以上を要求するようになりデプロイが失敗していた。

## 変更内容

- `amondnet/vercel-action` を v25 → v42.2.0 (commit hash) に更新
- `actions/checkout` を v4 → v6.0.2 (commit hash) に更新